### PR TITLE
Add parameter user to run command with different user 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .project
 pkg
-metadata.json
 .rvmrc
 .ruby-version
 .ruby-gemset

--- a/Modulefile
+++ b/Modulefile
@@ -1,8 +1,0 @@
-name    'maestrodev-ssh_keygen'
-version '1.2.1'
-source 'http://github.com/maestrodev/puppet-ssh_keygen.git'
-author 'maestrodev'
-license 'Apache License, Version 2.0'
-summary 'Generate ssh keys with ssh_keygen'
-description 'Generate ssh keys for any user using ssh_keygen, that needs to be present before using the module'
-project_page 'http://github.com/maestrodev/puppet-ssh_keygen'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@ define ssh_keygen (
   $home     = undef,
   $user     = undef,
   $filename = undef,
-  $comment  = "${name}@${::fqdn}",
+  $comment  = undef,
   $type     = 'rsa',
   $bits     = '2048',
 ) {
@@ -32,8 +32,13 @@ define ssh_keygen (
     default => $filename,
   }
 
+  $comment_real = $comment ? {
+    undef   => "${user_real}@${::fqdn}",
+    default => $comment,
+  }
+
   exec { "ssh_keygen-${name}":
-    command => "ssh-keygen -t ${type} -b ${bits} -f \"${filename_real}\" -N '' -C '${comment}'",
+    command => "ssh-keygen -t ${type} -b ${bits} -f \"${filename_real}\" -N '' -C '${comment_real}'",
     user    => $user_real,
     creates => $filename_real,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@
 #
 define ssh_keygen (
   $home     = "/home/${name}",
+  $user     = $name,
   $filename = undef,
   $comment  = "${name}@${::fqdn}",
   $type     = 'rsa',
@@ -23,7 +24,7 @@ define ssh_keygen (
 
   exec { "ssh_keygen-${name}":
     command => "ssh-keygen -t ${type} -b ${bits} -f \"${filename_real}\" -N '' -C '${comment}'",
-    user    => $name,
+    user    => $user,
     creates => $filename_real,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,8 +7,8 @@
 # $bits
 #
 define ssh_keygen (
-  $home     = "/home/${name}",
-  $user     = $name,
+  $home     = undef,
+  $user     = undef,
   $filename = undef,
   $comment  = "${name}@${::fqdn}",
   $type     = 'rsa',
@@ -17,14 +17,24 @@ define ssh_keygen (
 
   Exec { path => '/bin:/usr/bin' }
 
+  $user_real = $user ? {
+    undef   => $name,
+    default => $user,
+  }
+
+  $home_real = $home ? {
+    undef   => "/home/${user_real}",
+    default => $home,
+  }
+
   $filename_real = $filename ? {
-    undef   => "${home}/.ssh/id_${type}",
+    undef   => "${home_real}/.ssh/id_${type}",
     default => $filename,
   }
 
   exec { "ssh_keygen-${name}":
     command => "ssh-keygen -t ${type} -b ${bits} -f \"${filename_real}\" -N '' -C '${comment}'",
-    user    => $user,
+    user    => $user_real,
     creates => $filename_real,
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,12 @@
+{
+  "name": "maestrodev-ssh_keygen",
+  "version": "1.2.1",
+  "source": "http://github.com/maestrodev/puppet-ssh_keygen.git",
+  "author": "maestrodev",
+  "license": "Apache License, Version 2.0",
+  "summary": "Generate ssh keys with ssh_keygen",
+  "description": "Generate ssh keys for any user using ssh_keygen, that needs to be present before using the module",
+  "project_page": "http://github.com/maestrodev/puppet-ssh_keygen",
+  "dependencies": [
+  ]
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "maestrodev-ssh_keygen",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "source": "http://github.com/maestrodev/puppet-ssh_keygen.git",
   "author": "maestrodev",
   "license": "Apache License, Version 2.0",

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -70,7 +70,7 @@ describe 'ssh_keygen' do
     let(:params) { {:user => 'other'} }
 
     it { should contain_exec('ssh_keygen-john').with(
-      :command => "ssh-keygen -t rsa -b 2048 -f \"/home/other/.ssh/id_rsa\" -N '' -C 'john@www.acme.com'",
+      :command => "ssh-keygen -t rsa -b 2048 -f \"/home/other/.ssh/id_rsa\" -N '' -C 'other@www.acme.com'",
       :user    => 'other',
       :creates => '/home/other/.ssh/id_rsa'
     ) }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -66,4 +66,14 @@ describe 'ssh_keygen' do
     ) }
   end
 
+  context 'passing user parameter' do
+    let(:params) { {:user => 'other'} }
+
+    it { should contain_exec('ssh_keygen-john').with(
+      :command => "ssh-keygen -t rsa -b 2048 -f \"/home/john/.ssh/id_rsa\" -N '' -C 'john@www.acme.com'",
+      :user    => 'other',
+      :creates => '/home/john/.ssh/id_rsa'
+    ) }
+  end
+
 end

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -70,9 +70,9 @@ describe 'ssh_keygen' do
     let(:params) { {:user => 'other'} }
 
     it { should contain_exec('ssh_keygen-john').with(
-      :command => "ssh-keygen -t rsa -b 2048 -f \"/home/john/.ssh/id_rsa\" -N '' -C 'john@www.acme.com'",
+      :command => "ssh-keygen -t rsa -b 2048 -f \"/home/other/.ssh/id_rsa\" -N '' -C 'john@www.acme.com'",
       :user    => 'other',
-      :creates => '/home/john/.ssh/id_rsa'
+      :creates => '/home/other/.ssh/id_rsa'
     ) }
   end
 


### PR DESCRIPTION
This is needed to create multiple ssh-keys via different resource-titles and given filenames in the home directory of a specific user.