### PR TITLE
Prefer command defaults for bits and comment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (2.2.8)
-    activemodel (4.2.3)
-      activesupport (= 4.2.3)
+    activemodel (4.2.4)
+      activesupport (= 4.2.4)
       builder (~> 3.1)
-    activesupport (4.2.3)
+    activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -16,13 +16,14 @@ GEM
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    aws-sdk (1.64.0)
-      aws-sdk-v1 (= 1.64.0)
-    aws-sdk-v1 (1.64.0)
+    aws-sdk (1.66.0)
+      aws-sdk-v1 (= 1.66.0)
+    aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    beaker (2.16.0)
+    beaker (2.23.0)
       aws-sdk (~> 1.57)
+      beaker-answers (~> 0.0)
       docker-api
       fission (~> 0.4)
       fog (~> 1.25)
@@ -36,8 +37,12 @@ GEM
       open_uri_redirections (~> 0.2.1)
       rbvmomi (~> 1.8)
       rsync (~> 1.0.9)
+      stringify-hash (~> 0.0)
       unf (~> 0.1)
-    beaker-rspec (5.1.0)
+    beaker-answers (0.2.2)
+      require_all (~> 1.3.2)
+      stringify-hash (~> 0.0.0)
+    beaker-rspec (5.2.2)
       beaker (~> 2.0)
       rspec
       serverspec (~> 2)
@@ -45,12 +50,12 @@ GEM
     builder (3.2.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    docker-api (1.21.4)
+    docker-api (1.22.4)
       excon (>= 0.38.0)
       json
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
-    excon (0.45.3)
+    excon (0.45.4)
     extlib (0.9.16)
     facter (2.4.4)
       CFPropertyList (~> 2.2.6)
@@ -58,12 +63,13 @@ GEM
       multipart-post (>= 1.2, < 3)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.32.0)
+    fog (1.34.0)
       fog-atmos
       fog-aws (>= 0.6.0)
       fog-brightbox (~> 0.4)
       fog-core (~> 1.32)
-      fog-ecloud (= 0.1.1)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
       fog-google (>= 0.0.2)
       fog-json
       fog-local
@@ -84,23 +90,27 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.7.1)
+    fog-aws (0.7.6)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.7.2)
+    fog-brightbox (0.9.0)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.32.0)
+    fog-core (1.32.1)
       builder
       excon (~> 0.45)
       formatador (~> 0.2)
       mime-types
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
-    fog-ecloud (0.1.1)
+    fog-dynect (0.0.2)
+      fog-core
+      fog-json
+      fog-xml
+    fog-ecloud (0.3.0)
       fog-core
       fog-xml
     fog-google (0.0.7)
@@ -116,7 +126,7 @@ GEM
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
-    fog-profitbricks (0.0.3)
+    fog-profitbricks (0.0.5)
       fog-core
       fog-xml
       nokogiri
@@ -128,7 +138,7 @@ GEM
       fog-core
       fog-json
       fog-xml
-    fog-sakuracloud (1.0.1)
+    fog-sakuracloud (1.1.1)
       fog-core
       fog-json
     fog-serverlove (0.1.2)
@@ -164,21 +174,21 @@ GEM
       multi_json (~> 1.10)
       retriable (~> 1.4)
       signet (~> 0.6)
-    googleauth (0.4.1)
+    googleauth (0.4.2)
       faraday (~> 0.9)
       jwt (~> 1.4)
       logging (~> 2.0)
       memoist (~> 0.12)
-      multi_json (= 1.11)
+      multi_json (~> 1.11)
       signet (~> 0.6)
-    her (0.7.6)
-      activemodel (>= 3.0.0, <= 4.3.0)
-      activesupport (>= 3.0.0, <= 4.3.0)
-      faraday (>= 0.8, < 1.0)
+    her (0.6.8)
+      activemodel (>= 3.0.0)
+      activesupport (>= 3.0.0)
+      faraday (~> 0.8)
       multi_json (~> 1.7)
-    hiera (2.0.0)
+    hiera (3.0.1)
       json_pure
-    hocon (0.9.2)
+    hocon (0.9.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -196,7 +206,7 @@ GEM
       rsync
     librarianp (0.6.3)
       thor (~> 0.15)
-    little-plugger (1.1.3)
+    little-plugger (1.1.4)
     logging (2.0.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
@@ -204,10 +214,10 @@ GEM
     metaclass (0.0.4)
     mime-types (2.6.1)
     mini_portile (0.6.2)
-    minitest (5.7.0)
+    minitest (5.8.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    multi_json (1.11.0)
+    multi_json (1.11.2)
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -217,9 +227,9 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     open_uri_redirections (0.2.1)
-    puppet (4.2.0)
+    puppet (4.2.1)
       facter (> 2.0, < 4)
-      hiera (>= 2.0, < 3)
+      hiera (>= 2.0, < 4)
       json_pure
     puppet-blacksmith (3.3.1)
       puppet (>= 2.7.16)
@@ -227,8 +237,8 @@ GEM
     puppet-lint (1.1.0)
     puppet-syntax (2.0.0)
       rake
-    puppet_forge (1.0.4)
-      her (~> 0.6)
+    puppet_forge (1.0.5)
+      her (~> 0.6.8)
     puppetlabs_spec_helper (0.10.3)
       mocha
       puppet-lint
@@ -240,6 +250,7 @@ GEM
       builder
       nokogiri (>= 1.4.1)
       trollop
+    require_all (1.3.2)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -249,26 +260,26 @@ GEM
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
       rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.1)
+    rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.0)
+    rspec-expectations (3.3.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-its (1.2.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.3.1)
+    rspec-mocks (3.3.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-puppet (2.2.0)
       rspec
     rspec-support (3.3.0)
     rsync (1.0.9)
-    serverspec (2.19.0)
+    serverspec (2.23.1)
       multi_json
       rspec (~> 3.0)
       rspec-its
-      specinfra (~> 2.35)
+      specinfra (~> 2.43)
     sfl (2.2)
     signet (0.6.1)
       addressable (~> 2.3)
@@ -281,11 +292,12 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    specinfra (2.37.0)
+    specinfra (2.43.3)
       net-scp
-      net-ssh
+      net-ssh (~> 2.7)
       net-telnet
       sfl
+    stringify-hash (0.0.2)
     thor (0.19.1)
     thread_safe (0.3.5)
     trollop (2.1.2)
@@ -308,3 +320,6 @@ DEPENDENCIES
   rake
   rspec-puppet (>= 2.1.0)
   simplecov
+
+BUNDLED WITH
+   1.10.6

--- a/Rakefile
+++ b/Rakefile
@@ -29,4 +29,5 @@ Blacksmith::RakeTask.new do |t|
   t.build = false # do not build the module nor push it to the Forge, just do the tagging [:clean, :tag, :bump_commit]
 end
 
+Rake::Task[:default].prerequisites.clear
 task :default => [:clean, :validate, :lint, :spec]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,7 +31,10 @@ define ssh_keygen (
   }
 
   $home_real = $home ? {
-    undef   => "/home/${user_real}",
+    undef   => $user_real ? {
+      'root'  => "/${user_real}",
+      default => "/home/${user_real}",
+    },
     default => $home,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,18 +1,21 @@
 # Define: ssh_keygen
 # Parameters:
+# $user
+# $type
+# $bits
 # $home
 # $filename
 # $comment
-# $type
-# $bits
+# $options
 #
 define ssh_keygen (
-  $home     = undef,
   $user     = undef,
+  $type     = undef,
+  $bits     = undef,
+  $home     = undef,
   $filename = undef,
   $comment  = undef,
-  $type     = 'rsa',
-  $bits     = '2048',
+  $options  = undef,
 ) {
 
   Exec { path => '/bin:/usr/bin' }
@@ -22,23 +25,33 @@ define ssh_keygen (
     default => $user,
   }
 
+  $type_real = $type ? {
+    undef   => 'rsa',
+    default => $type,
+  }
+
   $home_real = $home ? {
     undef   => "/home/${user_real}",
     default => $home,
   }
 
   $filename_real = $filename ? {
-    undef   => "${home_real}/.ssh/id_${type}",
+    undef   => "${home_real}/.ssh/id_${type_real}",
     default => $filename,
   }
 
-  $comment_real = $comment ? {
-    undef   => "${user_real}@${::fqdn}",
-    default => $comment,
+  $type_opt = " -t ${type_real}"
+  if $bits { $bits_opt = " -b ${bits}" }
+  $filename_opt = " -f '${filename_real}'"
+  $n_passphrase_opt = " -N ''"
+  if $comment { $comment_opt = " -C '${comment}'" }
+  $options_opt = $options ? {
+    undef   => undef,
+    default => " ${options}",
   }
 
   exec { "ssh_keygen-${name}":
-    command => "ssh-keygen -t ${type} -b ${bits} -f \"${filename_real}\" -N '' -C '${comment_real}'",
+    command => "ssh-keygen${type_opt}${bits_opt}${filename_opt}${n_passphrase_opt}${comment_opt}${options_opt}",
     user    => $user_real,
     creates => $filename_real,
   }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -9,58 +9,7 @@ describe 'ssh_keygen' do
     let(:params) { {} }
 
     it { should contain_exec('ssh_keygen-john').with(
-      :command => "ssh-keygen -t rsa -b 2048 -f \"/home/john/.ssh/id_rsa\" -N '' -C 'john@www.acme.com'",
-      :user    => 'john',
-      :creates => '/home/john/.ssh/id_rsa'
-    ) }
-  end
-
-  context 'passing home parameter' do
-    let(:params) { {:home => '/h/j'} }
-
-    it { should contain_exec('ssh_keygen-john').with(
-      :command => "ssh-keygen -t rsa -b 2048 -f \"/h/j/.ssh/id_rsa\" -N '' -C 'john@www.acme.com'",
-      :user    => 'john',
-      :creates => '/h/j/.ssh/id_rsa'
-    ) }
-  end
-
-  context 'passing filename parameter for host key' do
-    let(:title)  { 'root' }
-    let(:params) { {:filename => '/etc/ssh/ssh_host_rsa_key'} }
-
-    it { should contain_exec('ssh_keygen-root').with(
-      :command => "ssh-keygen -t rsa -b 2048 -f \"/etc/ssh/ssh_host_rsa_key\" -N '' -C 'root@www.acme.com'",
-      :user    => 'root',
-      :creates => '/etc/ssh/ssh_host_rsa_key'
-    ) }
-  end
-
-  context 'passing comment parameter' do
-    let(:params) { {:comment => 'my key'} }
-
-    it { should contain_exec('ssh_keygen-john').with(
-      :command => "ssh-keygen -t rsa -b 2048 -f \"/home/john/.ssh/id_rsa\" -N '' -C 'my key'",
-      :user    => 'john',
-      :creates => '/home/john/.ssh/id_rsa'
-    ) }
-  end
-
-  context 'passing type parameter' do
-    let(:params) { {:type => 'dsa'} }
-
-    it { should contain_exec('ssh_keygen-john').with(
-      :command => "ssh-keygen -t dsa -b 2048 -f \"/home/john/.ssh/id_dsa\" -N '' -C 'john@www.acme.com'",
-      :user    => 'john',
-      :creates => '/home/john/.ssh/id_dsa'
-    ) }
-  end
-
-  context 'passing bits parameter' do
-    let(:params) { {:bits => '4096'} }
-
-    it { should contain_exec('ssh_keygen-john').with(
-      :command => "ssh-keygen -t rsa -b 4096 -f \"/home/john/.ssh/id_rsa\" -N '' -C 'john@www.acme.com'",
+      :command => "ssh-keygen -t rsa -f '/home/john/.ssh/id_rsa' -N ''",
       :user    => 'john',
       :creates => '/home/john/.ssh/id_rsa'
     ) }
@@ -70,9 +19,70 @@ describe 'ssh_keygen' do
     let(:params) { {:user => 'other'} }
 
     it { should contain_exec('ssh_keygen-john').with(
-      :command => "ssh-keygen -t rsa -b 2048 -f \"/home/other/.ssh/id_rsa\" -N '' -C 'other@www.acme.com'",
+      :command => "ssh-keygen -t rsa -f '/home/other/.ssh/id_rsa' -N ''",
       :user    => 'other',
       :creates => '/home/other/.ssh/id_rsa'
+    ) }
+  end
+
+  context 'passing type parameter' do
+    let(:params) { {:type => 'dsa'} }
+
+    it { should contain_exec('ssh_keygen-john').with(
+      :command => "ssh-keygen -t dsa -f '/home/john/.ssh/id_dsa' -N ''",
+      :user    => 'john',
+      :creates => '/home/john/.ssh/id_dsa'
+    ) }
+  end
+
+  context 'passing bits parameter' do
+    let(:params) { {:bits => '4096'} }
+
+    it { should contain_exec('ssh_keygen-john').with(
+      :command => "ssh-keygen -t rsa -b 4096 -f '/home/john/.ssh/id_rsa' -N ''",
+      :user    => 'john',
+      :creates => '/home/john/.ssh/id_rsa'
+    ) }
+  end
+
+  context 'passing home parameter' do
+    let(:params) { {:home => '/h/j'} }
+
+    it { should contain_exec('ssh_keygen-john').with(
+      :command => "ssh-keygen -t rsa -f '/h/j/.ssh/id_rsa' -N ''",
+      :user    => 'john',
+      :creates => '/h/j/.ssh/id_rsa'
+    ) }
+  end
+
+  context 'passing filename parameter' do
+    let(:title)  { 'root' }
+    let(:params) { {:filename => '/etc/ssh/ssh_host_rsa_key'} }
+
+    it { should contain_exec('ssh_keygen-root').with(
+      :command => "ssh-keygen -t rsa -f '/etc/ssh/ssh_host_rsa_key' -N ''",
+      :user    => 'root',
+      :creates => '/etc/ssh/ssh_host_rsa_key'
+    ) }
+  end
+
+  context 'passing comment parameter' do
+    let(:params) { {:comment => 'my key'} }
+
+    it { should contain_exec('ssh_keygen-john').with(
+      :command => "ssh-keygen -t rsa -f '/home/john/.ssh/id_rsa' -N '' -C 'my key'",
+      :user    => 'john',
+      :creates => '/home/john/.ssh/id_rsa'
+    ) }
+  end
+
+  context 'passing options parameter' do
+    let(:params) { {:options => '-q'} }
+
+    it { should contain_exec('ssh_keygen-john').with(
+      :command => "ssh-keygen -t rsa -f '/home/john/.ssh/id_rsa' -N '' -q",
+      :user    => 'john',
+      :creates => '/home/john/.ssh/id_rsa'
     ) }
   end
 

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -15,13 +15,23 @@ describe 'ssh_keygen' do
     ) }
   end
 
-  context 'passing user parameter' do
+  context 'passing user other parameter' do
     let(:params) { {:user => 'other'} }
 
     it { should contain_exec('ssh_keygen-john').with(
       :command => "ssh-keygen -t rsa -f '/home/other/.ssh/id_rsa' -N ''",
       :user    => 'other',
       :creates => '/home/other/.ssh/id_rsa'
+    ) }
+  end
+
+  context 'passing user root parameter' do
+    let(:params) { {:user => 'root'} }
+
+    it { should contain_exec('ssh_keygen-john').with(
+      :command => "ssh-keygen -t rsa -f '/root/.ssh/id_rsa' -N ''",
+      :user    => 'root',
+      :creates => '/root/.ssh/id_rsa'
     ) }
   end
 


### PR DESCRIPTION
If not specified, then let the ssh-keygen command use its defaults for bits and comment, rather than setting our own.

This fixes the case of using dsa with no bits set, since dsa can not have 2048 bits, which was our default.

The last commit also adds a new parameter for passing in extra options.